### PR TITLE
gui: remember last played game when it is the first list entry

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1155,7 +1155,13 @@ static void guiHandleOp(struct gui_update_t *item)
                 item->menu.menu->submenu = result;
                 item->menu.menu->current = result;
                 item->menu.menu->pagestart = result;
-            } else if (item->submenu.selected) { // remember last played game feature
+            }
+
+            // Deliberately not an "else if": when the last played game is the
+            // first entry of the unsorted list, the branch above consumes it
+            // and remindLast is never set, so GUI_OP_SORT would move the
+            // cursor back to the top of the sorted list.
+            if (item->submenu.selected) { // remember last played game feature
                 item->menu.menu->current = result;
                 item->menu.menu->pagestart = result;
                 item->menu.menu->remindLast = 1;


### PR DESCRIPTION
## Problem

With "remember last played" enabled, exactly one game per device list is never restored,
and the Last Played Auto Start countdown never fires for it. Which game that is looks
arbitrary from the outside: it is whichever entry ends up at index 0 of the unsorted list,
which in practice is usually the most recently copied ISO.

## Cause

`updateMenuFromGameList()` flags the remembered game with `submenu.selected`, and
`GUI_OP_APPEND_MENU` turns that flag into `menu->remindLast`. That branch is chained as an
`else if` to the "first subitem in list" case:

```c
if (!item->menu.menu->submenu) { // first subitem in list
    ...
} else if (item->submenu.selected) { // remember last played game feature
    ...
    item->menu.menu->remindLast = 1;
```

When the remembered game is the first item appended, the first branch consumes it and
`remindLast` is never set. `GUI_OP_SORT` then runs:

```c
if (!item->menu.menu->remindLast)
    item->menu.menu->current = item->menu.menu->submenu;
```

and the cursor goes back to the top of the alphabetically sorted list. The same branch
also holds the `DisableCron = 0` that releases the auto start counter, so that never fires
for this entry either.

Which entry sits at index 0 is not visible to the user: `sbReadList()` stores the `ul.cfg`
entries first, and `scanForISO()` prepends each entry while walking the directory, so the
last file `readdir()` returns is the one that ends up first.

## Fix

Split the chain into two independent `if`s. Behaviour is unchanged for every other entry;
for index 0 the second block simply re-assigns the same node and raises `remindLast`.

## Testing

Reproduced on real hardware with the most recently copied ISO on an MMCE device: the game
id was written to `wopl_last_played.cfg` correctly, but the list always opened on the first
entry and no auto start countdown appeared. With this patch the same game is restored as
the selected item and the countdown shows up. Every other game in the list behaves exactly
as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
